### PR TITLE
WebSearch: Inline Citations

### DIFF
--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -25,6 +25,14 @@
 	import { base } from "$app/paths";
 	import { useConvTreeStore } from "$lib/stores/convTree";
 
+	function addInlineCitations(md: string, webSearchSources: WebSearchUpdate["sources"] = []) {
+		return md.replace(/ *\[(\d+)\]/g, (textToReplace, index) => {
+			const source = webSearchSources[Number(index) - 1];
+			if (!source) return textToReplace;
+			return ` <sup><a href="${source.link}" target="_blank" rel="noreferrer" class="text-primary-400 no-underline hover:underline font-bold">${index}</a></sup>`;
+		});
+	}
+
 	function sanitizeMd(md: string) {
 		let ret = md
 			.replace(/<\|[a-z]*$/, "")
@@ -100,7 +108,7 @@
 		})
 	);
 
-	$: tokens = marked.lexer(sanitizeMd(message.content));
+	$: tokens = marked.lexer(addInlineCitations(sanitizeMd(message.content), webSearchSources));
 
 	$: emptyLoad =
 		!message.content && (webSearchIsDone || (searchUpdates && searchUpdates.length === 0));

--- a/src/lib/components/chat/ChatMessage.svelte
+++ b/src/lib/components/chat/ChatMessage.svelte
@@ -26,9 +26,9 @@
 	import { useConvTreeStore } from "$lib/stores/convTree";
 
 	function addInlineCitations(md: string, webSearchSources: WebSearchUpdate["sources"] = []) {
-		return md.replace(/ *\[(\d+)\]/g, (textToReplace, index) => {
+		return md.replace(/ *\[\[(\d+)\]\]/gm, (textToReplace, index) => {
 			const source = webSearchSources[Number(index) - 1];
-			if (!source) return textToReplace;
+			if (!source) return "";
 			return ` <sup><a href="${source.link}" target="_blank" rel="noreferrer" class="text-primary-400 no-underline hover:underline font-bold">${index}</a></sup>`;
 		});
 	}

--- a/src/lib/server/preprocessMessages.ts
+++ b/src/lib/server/preprocessMessages.ts
@@ -13,7 +13,7 @@ export async function preprocessMessages(
 	return await Promise.all(
 		structuredClone(messages).map(async (message, idx) => {
 			const webSearchContext = webSearch?.contextSources
-				.map(({ context }, citationIdx) => `[${citationIdx + 1}]: ${context.trim()}`)
+				.map(({ context }, citationIdx) => `[[${citationIdx + 1}]]: ${context.trim()}`)
 				.join("\n\n----------\n\n");
 
 			// start by adding websearch to the last message
@@ -26,8 +26,8 @@ export async function preprocessMessages(
 				const currentDate = format(new Date(), "MMMM d, yyyy");
 
 				message.content = `I searched the web using the query: ${webSearch.searchQuery}
-When referencing the following results, include an inline citation like [1] [2] [3] etc in your answer at the end of the relevant chunk of text. Do not include a dedicated citation/sources section.
-Today is ${currentDate} and here are the results:
+Please format your response to include inline citation numbers like [[1]], [[2]], etc. whenever referencing information from an external source. Place these inline citations at the end of the relevant sentence or paragraph. Do not include a list of sources or references at the end of your response.
+Today is ${currentDate} and here is a list of sources:
 =====================
 ${webSearchContext}
 =====================

--- a/src/lib/server/preprocessMessages.ts
+++ b/src/lib/server/preprocessMessages.ts
@@ -13,7 +13,7 @@ export async function preprocessMessages(
 	return await Promise.all(
 		structuredClone(messages).map(async (message, idx) => {
 			const webSearchContext = webSearch?.contextSources
-				.map(({ context }) => context.trim())
+				.map(({ context }, citationIdx) => `[${citationIdx + 1}]: ${context.trim()}`)
 				.join("\n\n----------\n\n");
 
 			// start by adding websearch to the last message
@@ -25,7 +25,8 @@ export async function preprocessMessages(
 					.map((el) => el.content);
 				const currentDate = format(new Date(), "MMMM d, yyyy");
 
-				message.content = `I searched the web using the query: ${webSearch.searchQuery}.
+				message.content = `I searched the web using the query: ${webSearch.searchQuery}
+When referencing the following results, include an inline citation like [1] [2] [3] etc in your answer at the end of the relevant chunk of text. Do not include a dedicated citation/sources section.
 Today is ${currentDate} and here are the results:
 =====================
 ${webSearchContext}


### PR DESCRIPTION
Adds support for inline citations by prefixing each source with `[[idx]]` and requesting that the model include that in its output. It then replaces any instances of these during runtime with a link to source in superscript.

![image](https://github.com/superfishial/chat-ui/assets/10467983/d1fffe87-7d67-43d9-88b5-e633f98e0873)
